### PR TITLE
Support future type hint syntax when evaluating forward refeferences

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -6,12 +6,3 @@ author = "@NiklasRosenstein"
 issues = [
     "https://github.com/NiklasRosenstein/python-typeapi/issues/5",
 ]
-
-[[entries]]
-id = "aef2834d-dca0-4b47-9ed0-c891a33b3101"
-type = "feature"
-description = "support future typing syntax (such as `list[int]` and `int | None`) when evaluating forward references."
-author = "@NiklasRosenstein"
-issues = [
-    "https://github.com/NiklasRosenstein/python-typeapi/issues/5",
-]

--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -1,0 +1,17 @@
+[[entries]]
+id = "d5e6704b-34d8-4345-b307-00469e03f001"
+type = "feature"
+description = "support future typing syntax (such as `list[int]` and `int | None`) when evaluating forward references."
+author = "@NiklasRosenstein"
+issues = [
+    "https://github.com/NiklasRosenstein/python-typeapi/issues/5",
+]
+
+[[entries]]
+id = "aef2834d-dca0-4b47-9ed0-c891a33b3101"
+type = "feature"
+description = "support future typing syntax (such as `list[int]` and `int | None`) when evaluating forward references."
+author = "@NiklasRosenstein"
+issues = [
+    "https://github.com/NiklasRosenstein/python-typeapi/issues/5",
+]

--- a/readme.md
+++ b/readme.md
@@ -2,11 +2,17 @@
 
 [![Python](https://github.com/NiklasRosenstein/python-typeapi/actions/workflows/python.yml/badge.svg)](https://github.com/NiklasRosenstein/python-typeapi/actions/workflows/python.yml)
 
+  [PEP484]: https://peps.python.org/pep-0484/
+  [PEP585]: https://peps.python.org/pep-0585/
+  [PEP604]: https://peps.python.org/pep-0604/
+
 __Compatibility__: Python 3.6.3+
 
-The `typeapi` package provides an object-oriented interface for introspecting type hints from the `typing` and
-`typing_extensions` module at runtime. Currently, only a subset of the different kinds of type hints are supported,
-namely through the following representations:
+The `typeapi` package provides an object-oriented interface for introspecting [PEP484][] type hints at runtime,
+including forward references that make use of the more recent [PEP585][] and [PEP604][] type hint features in
+Python versions that don't natively support them.
+
+The following kinds of type hints are currently supported:
 
 | Concrete type | Description | Added in |
 | ------------- | ----------- | -------- |

--- a/src/typeapi/future/astrewrite.py
+++ b/src/typeapi/future/astrewrite.py
@@ -1,0 +1,131 @@
+"""
+Rewrite a Python AST to make name lookups, writes and deletes delegate to a single global variable.
+"""
+
+import ast
+import contextlib
+import dataclasses
+import typing as t
+from types import CodeType
+
+T_AST = t.TypeVar("T_AST", bound=ast.AST)
+
+
+def rewrite_expr(source: str, lookup_target: str) -> CodeType:
+    expr = ast.parse(source, "<expr>", "eval")
+    expr = DynamicLookupRewriter(lookup_target).visit(expr)
+    ast.fix_missing_locations(expr)
+    return compile(expr, "<expr>", "eval")
+
+
+@dataclasses.dataclass
+class DynamicLookupRewriter(ast.NodeTransformer):
+    # TODO(NiklasRosenstein): Handle more nodes that define local variables and := operator.
+
+    #: The variable name of the target object that name resolution should occur through.
+    #: All names in the AST, with a few exceptions, will be replaced by a getitem/setitem/delitem
+    #: expression on the variable name defined here.
+    lookup_target: str
+
+    #: Names to not replace. The #lookup_target does not need to be added here explicitly.
+    pure_builtins: t.Collection[str] = dataclasses.field(default_factory=frozenset)
+
+    #: A prefix to compare variable names for which, if it matches, they will not be replaced
+    #: with a dynamic lookup, but instead the prefix will be trimmed.
+    ignore_prefix: "str | None" = None
+
+    def __post_init__(self) -> None:
+        self._locals: t.List[t.Set[str]] = [set()]
+
+    def _add_to_locals(self, varnames: t.Set[str]) -> None:
+        assert self._locals, "no locals in current scope"
+        self._locals[-1].update(varnames)
+
+    @contextlib.contextmanager
+    def _with_locals(self, varnames: t.Set[str]) -> t.Iterator[None]:
+        self._locals.append(varnames)
+        try:
+            yield
+        finally:
+            self._locals.pop()
+
+    @contextlib.contextmanager
+    def _with_locals_from_target(self, target: ast.expr) -> t.Iterator[None]:
+        names: t.Set[str] = set()
+        if isinstance(target, ast.Name):
+            names.add(target.id)
+        elif isinstance(target, (ast.List, ast.Tuple)):
+            names.update(n.id for n in target.elts)  # type: ignore  # TODO (@NiklasRosenstein)
+        else:
+            raise TypeError(f"expected Name/List/Tuple, got {type(target).__name__}")
+        with self._with_locals(names):
+            yield
+
+    def _has_local(self, varname: str) -> bool:
+        if self._locals:
+            return varname in self._locals[-1]
+        return False
+
+    def _has_nonlocal(self, varname: str) -> bool:
+        for locals in self._locals:
+            if varname in locals:
+                return True
+        return varname == self.lookup_target or varname in self.pure_builtins
+
+    def visit_Name(self, node: ast.Name) -> ast.AST:
+        if self._has_nonlocal(node.id):
+            return node
+        return ast.Subscript(
+            value=ast.Name(id=self.lookup_target, ctx=ast.Load()),
+            slice=ast.Index(value=ast.Constant(value=node.id)),
+            ctx=node.ctx,
+        )
+
+    def visit_Assign(self, assign: ast.Assign) -> ast.AST:
+        if len(assign.targets) == 1 and isinstance(assign.targets[0], ast.Name):
+            name = assign.targets[0]
+            if self.ignore_prefix is not None and name.id.startswith(self.ignore_prefix):
+                name.id = name.id[len(self.ignore_prefix) :]
+                self._add_to_locals({name.id})
+        return self.generic_visit(assign)
+
+    def visit_For(self, node: ast.For) -> ast.AST:
+        with self._with_locals_from_target(node.target):
+            return self.generic_visit(node)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> ast.AST:
+        self._add_to_locals({node.name})
+        names: t.Set[str] = set()
+        for arg in node.args.args:
+            names.add(arg.arg)
+        for arg in node.args.kwonlyargs:
+            names.add(arg.arg)
+        if node.args.vararg:
+            names.add(node.args.vararg.arg)
+        if node.args.kwarg:
+            names.add(node.args.kwarg.arg)
+        with self._with_locals(names):
+            return self.generic_visit(node)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> ast.AST:
+        self._add_to_locals({node.name})
+        return self.generic_visit(node)
+
+    def visit_Import(self, node: ast.Import) -> ast.AST:
+        names: t.Set[str] = set()
+        for name in node.names:
+            if name.asname:
+                names.add(name.asname)
+            elif "." in name.name:
+                names.add(name.name.rpartition(".")[0])
+            else:
+                names.add(name.name)
+        self._add_to_locals(names)
+        return self.generic_visit(node)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> ast.AST:
+        self.visit_Import(ast.Import(names=node.names))  # Dispatch name detection
+        return self.generic_visit(node)
+
+    def visit(self, node: T_AST) -> T_AST:
+        return super().visit(node)

--- a/src/typeapi/future/astrewrite.py
+++ b/src/typeapi/future/astrewrite.py
@@ -15,7 +15,7 @@ def rewrite_expr(source: str, lookup_target: str) -> CodeType:
     expr = ast.parse(source, "<expr>", "eval")
     expr = DynamicLookupRewriter(lookup_target).visit(expr)
     ast.fix_missing_locations(expr)
-    return compile(expr, "<expr>", "eval")
+    return t.cast(CodeType, compile(expr, "<expr>", "eval"))
 
 
 @dataclasses.dataclass
@@ -85,7 +85,7 @@ class DynamicLookupRewriter(ast.NodeTransformer):
         if len(assign.targets) == 1 and isinstance(assign.targets[0], ast.Name):
             name = assign.targets[0]
             if self.ignore_prefix is not None and name.id.startswith(self.ignore_prefix):
-                name.id = name.id[len(self.ignore_prefix) :]
+                name.id = name.id[len(self.ignore_prefix) :]  # noqa: E203
                 self._add_to_locals({name.id})
         return self.generic_visit(assign)
 
@@ -127,5 +127,5 @@ class DynamicLookupRewriter(ast.NodeTransformer):
         self.visit_Import(ast.Import(names=node.names))  # Dispatch name detection
         return self.generic_visit(node)
 
-    def visit(self, node: T_AST) -> T_AST:
+    def visit(self, node: T_AST) -> t.Any:
         return super().visit(node)

--- a/src/typeapi/future/fake.py
+++ b/src/typeapi/future/fake.py
@@ -13,7 +13,7 @@ class FakeHint:
     A placeholder for an actual type hint.
     """
 
-    def __init__(self, origin: Any, args: Optional[Tuple["FakeHint"]] = None) -> None:
+    def __init__(self, origin: Any, args: Optional[Tuple["FakeHint", ...]] = None) -> None:
         self.origin = origin
         self.args = args
 

--- a/src/typeapi/future/fake.py
+++ b/src/typeapi/future/fake.py
@@ -1,0 +1,50 @@
+"""
+Here we provide support to mock support of future type hint feature for older Python versions.
+"""
+
+import builtins
+from typing import Any, Optional, Tuple, Union
+
+from ..utils import HasGetitem, get_subscriptable_type_hint_from_origin
+
+
+class FakeHint:
+    """
+    A placeholder for an actual type hint.
+    """
+
+    def __init__(self, origin: Any, args: Optional[Tuple["FakeHint"]] = None) -> None:
+        self.origin = origin
+        self.args = args
+
+    def __or__(self, other: "FakeHint") -> "FakeHint":
+        assert isinstance(other, FakeHint)
+        if self.origin == Union:
+            assert self.args is not None
+            return FakeHint(Union, self.args + (other,))
+        return FakeHint(Union, (self, other))
+
+    def __getitem__(self, args: Union[Any, Tuple[Any, ...]]) -> "FakeHint":
+        if self.args:
+            raise RuntimeError(f"cannot subscript already subscripted type hint ({self})")
+        if not isinstance(args, tuple):
+            args = (args,)
+        return FakeHint(self.origin, tuple(x if isinstance(x, FakeHint) else FakeHint(x) for x in args))
+
+    def evaluate(self) -> Any:
+        if self.args is None:
+            return self.origin
+        else:
+            return self.origin[tuple(x.evaluate() for x in self.args)]
+
+
+class FakeProvider:
+    def __init__(self, content: HasGetitem[str, Any]) -> None:
+        self.content = content
+
+    def __getitem__(self, key: str) -> FakeHint:
+        try:
+            value = self.content[key]
+        except KeyError:
+            value = vars(builtins)[key]
+        return FakeHint(get_subscriptable_type_hint_from_origin(value))

--- a/src/typeapi/future/fake_test.py
+++ b/src/typeapi/future/fake_test.py
@@ -1,3 +1,4 @@
+import sys
 from typing import List, Optional, Union
 
 import pytest
@@ -22,4 +23,7 @@ def test__FakeHint__subscript() -> None:
 
     with pytest.raises(TypeError) as excinfo:
         FakeHint(int)[FakeHint(str)].evaluate()
-    assert str(excinfo.value) == "'type' object is not subscriptable"
+    if sys.version_info[:2] <= (3, 10):
+        assert str(excinfo.value) == "'type' object is not subscriptable"
+    else:
+        assert str(excinfo.value) == "type 'int' is not subscriptable"

--- a/src/typeapi/future/fake_test.py
+++ b/src/typeapi/future/fake_test.py
@@ -1,0 +1,25 @@
+from typing import List, Optional, Union
+
+import pytest
+
+from typeapi.future.fake import FakeHint
+
+
+def test__FakeHint__evaluate() -> None:
+    assert FakeHint(int).evaluate() is int
+    assert FakeHint(Union, (FakeHint(int), FakeHint(str))).evaluate() == Union[int, str]
+
+
+def test__FakeHint__union() -> None:
+    assert (FakeHint(int) | FakeHint(str)).evaluate() == Union[int, str]
+    assert ((FakeHint(int) | FakeHint(str)) | FakeHint(float)).evaluate() == Union[int, str, float]
+    assert (FakeHint(int) | FakeHint(None)).evaluate() == Optional[int]
+
+
+def test__FakeHint__subscript() -> None:
+    assert FakeHint(Union)[FakeHint(int), FakeHint(str)].evaluate() == Union[int, str]
+    assert FakeHint(List)[FakeHint(int)].evaluate() == List[int]
+
+    with pytest.raises(TypeError) as excinfo:
+        FakeHint(int)[FakeHint(str)].evaluate()
+    assert str(excinfo.value) == "'type' object is not subscriptable"

--- a/src/typeapi/future/fake_test.py
+++ b/src/typeapi/future/fake_test.py
@@ -23,7 +23,4 @@ def test__FakeHint__subscript() -> None:
 
     with pytest.raises(TypeError) as excinfo:
         FakeHint(int)[FakeHint(str)].evaluate()
-    if sys.version_info[:2] <= (3, 10):
-        assert str(excinfo.value) == "'type' object is not subscriptable"
-    else:
-        assert str(excinfo.value) == "type 'int' is not subscriptable"
+    assert 'is not subscriptable ' in str(excinfo.value)

--- a/src/typeapi/future/fake_test.py
+++ b/src/typeapi/future/fake_test.py
@@ -1,4 +1,3 @@
-import sys
 from typing import List, Optional, Union
 
 import pytest
@@ -23,4 +22,4 @@ def test__FakeHint__subscript() -> None:
 
     with pytest.raises(TypeError) as excinfo:
         FakeHint(int)[FakeHint(str)].evaluate()
-    assert 'is not subscriptable' in str(excinfo.value)
+    assert "is not subscriptable" in str(excinfo.value)

--- a/src/typeapi/future/fake_test.py
+++ b/src/typeapi/future/fake_test.py
@@ -23,4 +23,4 @@ def test__FakeHint__subscript() -> None:
 
     with pytest.raises(TypeError) as excinfo:
         FakeHint(int)[FakeHint(str)].evaluate()
-    assert 'is not subscriptable ' in str(excinfo.value)
+    assert 'is not subscriptable' in str(excinfo.value)

--- a/src/typeapi/typehint.py
+++ b/src/typeapi/typehint.py
@@ -317,15 +317,28 @@ class ForwardRefTypeHint(TypeHint):
         )
 
     def evaluate(self, context: HasGetitem[str, Any]) -> TypeHint:
-        retyped_context = cast(Mapping[str, Any], context)
+        from .future.astrewrite import rewrite_expr
+        from .future.fake import FakeHint, FakeProvider
 
-        if IS_PYTHON_AT_LAST_3_6:
-            hint = eval(self.expr, {}, retyped_context)
-        elif IS_PYTHON_AT_LAST_3_8:
-            # Mypy doesn't know about the third arg
-            hint = self.ref._evaluate({}, retyped_context)  # type: ignore[arg-type]
-        else:
-            hint = self.ref._evaluate({}, retyped_context, set())  # type: ignore[arg-type,call-arg]
+        code = rewrite_expr(self.expr, "__dict__")
+        scope = {"__dict__": FakeProvider(context)}
+        hint = eval(code, scope, {})
+
+        assert isinstance(hint, FakeHint), (self.expr, FakeHint)
+        hint = hint.evaluate()
+
+        # # Even though eval expects a Mapping, we know for forward references that we'll only
+        # # need to have __getitem__() as they are pure expressions.
+        # retyped_context = cast(Mapping[str, Any], FakeProvider(context))
+
+        # if IS_PYTHON_AT_LAST_3_6:
+        #     hint = eval(code, scope, {})
+        # elif IS_PYTHON_AT_LAST_3_8:
+        #     # Mypy doesn't know about the third arg
+        #     hint = self.ref._evaluate(scope, {})  # type: ignore[arg-type]
+        # else:
+        #     hint = self.ref._evaluate(scope, {}, set())  # type: ignore[arg-type,call-arg]
+
         return TypeHint(hint).evaluate(context)
 
     @property

--- a/src/typeapi/typehint.py
+++ b/src/typeapi/typehint.py
@@ -1,11 +1,9 @@
 import abc
-from typing import Any, Dict, Generic, Iterator, List, Mapping, Tuple, TypeVar, Union, cast, overload
+from typing import Any, Dict, Generic, Iterator, List, Mapping, Tuple, TypeVar, Union, overload
 
 from typing_extensions import Annotated
 
 from .utils import (
-    IS_PYTHON_AT_LAST_3_6,
-    IS_PYTHON_AT_LAST_3_8,
     ForwardRef,
     HasGetitem,
     get_subscriptable_type_hint_from_origin,

--- a/src/typeapi/typehint_test.py
+++ b/src/typeapi/typehint_test.py
@@ -195,7 +195,7 @@ def test__TypeHint__from_TypeVar() -> None:
     assert hint.constraints == ()
 
 
-def test__TypeHint__from_ForwardRef_string() -> None:
+def test__TypeHint__from_string() -> None:
     hint = TypeHint("int")
     assert isinstance(hint, ForwardRefTypeHint)
     assert hint.hint == "int"
@@ -203,6 +203,16 @@ def test__TypeHint__from_ForwardRef_string() -> None:
     assert hint.args == ()
     assert hint.parameters == ()
     assert hint.ref == ForwardRef("int")
+
+
+def test__TypeHint__from_ForwardRef_with_literal() -> None:
+    hint = TypeHint(ForwardRef("Literal[42, 'universe']")).evaluate({"Literal": Literal})
+    assert isinstance(hint, LiteralTypeHint)
+    assert hint.hint == Literal[42, "universe"]
+    assert hint.origin is Literal
+    assert hint.args == ()
+    assert hint.values == (42, "universe")
+    assert hint.parameters == ()
 
 
 def test__TypeHint__from_ForwardRef_instance() -> None:
@@ -213,6 +223,24 @@ def test__TypeHint__from_ForwardRef_instance() -> None:
     assert hint.args == ()
     assert hint.parameters == ()
     assert hint.ref == ForwardRef("int")
+
+
+def test__TypeHint__from_future_syntax_ForwardRef_builtin_subscript() -> None:
+    hint = TypeHint(ForwardRef("list[int]")).evaluate({})
+    assert isinstance(hint, ClassTypeHint)
+    assert hint.hint == List[int]
+    assert hint.origin is list
+    assert hint.args == (int,)
+    assert hint.parameters == ()
+
+
+def test__TypeHint__from_future_syntax_ForwardRef_union() -> None:
+    hint = TypeHint(ForwardRef("int | list[int]")).evaluate({})
+    assert isinstance(hint, UnionTypeHint)
+    assert hint.hint == Union[int, List[int]]
+    assert hint.origin is Union
+    assert hint.args == (int, List[int])
+    assert hint.parameters == ()
 
 
 def test__ClassTypeHint__parametrize() -> None:
@@ -307,6 +335,7 @@ def test__TypeHint__evaluate_recursive() -> None:
     assert isinstance(hint, ForwardRefTypeHint)
 
     hint = hint.evaluate(globals())
+    assert hint.hint == List[int]
     assert isinstance(hint, ClassTypeHint), hint
     assert isinstance(hint[0], ClassTypeHint), hint[0]
 


### PR DESCRIPTION

  [PEP585]: https://peps.python.org/pep-0585/
  [PEP604]: https://peps.python.org/pep-0604/

This MR addresses #5 and allows `ForwardRefTypeHint.evaluate()` to evaluate forward references that use more recent Python type hint features such as [PEP585][] and [PEP604][].

This means that coder for older Python versions can make use of the new type hint features in forward references even if these hints needs to be inspected and evaluated with `typeapi`.