### PR TITLE
Support evaluation of future type hints in `typeapi.get_annotations()`

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -3,3 +3,9 @@ id = "1664da60-1b53-4b74-b61a-48b3e4fa4270"
 type = "fix"
 description = "provide experimental support for evaluating future type hints that perform a function call; sometimes this is used in the metadata for `Anntoated[...]` hints"
 author = "@NiklasRosenstein"
+
+[[entries]]
+id = "570591ef-afae-4637-8621-f788a52f83cc"
+type = "fix"
+description = "Support evaluation of future type hints in `typing.get_annotations()` and add new `typing.get_annotations(eval_str)` parameter. We backport a modified version of `inspect.get_annotations()` from Python 3.11 for this."
+author = "@NiklasRosenstein"

--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -7,5 +7,5 @@ author = "@NiklasRosenstein"
 [[entries]]
 id = "570591ef-afae-4637-8621-f788a52f83cc"
 type = "fix"
-description = "Support evaluation of future type hints in `typing.get_annotations()` and add new `typing.get_annotations(eval_str)` parameter. We backport a modified version of `inspect.get_annotations()` from Python 3.11 for this."
+description = "Support evaluation of future type hints in `typeapi.get_annotations()` and add new `typeapi.get_annotations(eval_str)` parameter. We backport a modified version of `inspect.get_annotations()` from Python 3.11 for this."
 author = "@NiklasRosenstein"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,14 @@ isort = "^5.10.1"
 flake8 = "^4.0.1"
 black = "^22.3.0"
 
-[tool.poetry.extras]
-docs = ["novella==0.1.12", "pydoc-markdown==4.6.3", "mkdocs", "mkdocs-material"]
+[tool.poetry.group.docs]
+optional = true
+
+[tool.poetry.group.docs.dependencies]
+mkdocs = "*"
+mkdocs-material = "*"
+novella = "0.2.3"
+pydoc-markdown = "4.6.0"
 
 [tool.slap]
 typed = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,7 @@
 [build-system]
-requires = ["poetry-core"]
+# NOTE(NiklasRosenstein): We pin this version so we can keep using the old way that Slap supports installing
+#                         the "docs" extra without Poetry complaining about invalid format of the requirements.
+requires = ["poetry-core==1.1.0a6"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
@@ -31,14 +33,20 @@ isort = "^5.10.1"
 flake8 = "^4.0.1"
 black = "^22.3.0"
 
-[tool.poetry.group.docs]
-optional = true
+[tool.poetry.extras]
+docs = ["novella==0.1.12", "pydoc-markdown==4.6.3", "mkdocs", "mkdocs-material"]
 
-[tool.poetry.group.docs.dependencies]
-mkdocs = "*"
-mkdocs-material = "*"
-novella = "0.2.3"
-pydoc-markdown = "4.6.0"
+# For newer Poetry Core versions only. We need to stick with the old way that Poetry doesn't complain
+#   about in older versions but work with Slap above.
+#
+# [tool.poetry.group.docs]
+# optional = true
+#
+# [tool.poetry.group.docs.dependencies]
+# mkdocs = "*"
+# mkdocs-material = "*"
+# novella = "0.2.3"
+# pydoc-markdown = "4.6.0"
 
 [tool.slap]
 typed = true

--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,11 @@ The `typeapi` package provides an object-oriented interface for introspecting [P
 including forward references that make use of the more recent [PEP585][] and [PEP604][] type hint features in
 Python versions that don't natively support them.
 
+The main API of this module is comprised of:
+
+* `typeapi.TypeHint()` &ndash; A class to parse low-level type hints and present them in a consistent, object-oriented API.
+* `typeapi.get_annotations()` &ndash; Retrieve an object's `__annotations__` with support for evaluating future type hints ([PEP585][], [PEP604][]).
+
 The following kinds of type hints are currently supported:
 
 | Concrete type | Description | Added in |
@@ -23,8 +28,6 @@ The following kinds of type hints are currently supported:
 | `TypeVarTypeHint` | Represents a `TypeVar` type hint and gives an interface to access the variable's metadata (such as constarints, variance, ...). | 1.0.0 |
 | `ForwardRefTypeHint` | Represents a forward reference. Can be evaluated in Python 3.6+ even if it contains [PEP585][] and [PEP604][] expressions. | 1.0.0, future support in 1.3.0 |
 | `TupleTypeHint` | Reperesents a `Tuple` type hint, allowing you to differentiate between repeated and explicitly sized tuples. | 1.2.0 |
-
-The main entry point to wrapping a low-level type hint is the `TypeHint()` constructor.
 
 ## Examples
 
@@ -85,7 +88,26 @@ assert isinstance(member_hint, ClassTypeHint)
 assert member_hint.type is int
 ```
 
-Evaluate forward references:
+Evaluate forward references with `get_annotations()`:
+
+```py
+# cat <<EOF | python -
+from typeapi import get_annotations
+from typing import Optional
+from sys import version_info
+
+class MyType:
+  a: "str | None"
+
+annotations = get_annotations(MyType)
+
+if version_info[:2] < (3, 10):
+  assert annotations == {"a": Optional[str]}
+else:
+  assert annotations == {"a": str | None}
+```
+
+Evaluating forward references with the `TypeHint` API:
 
 ```py
 # cat <<EOF | python -

--- a/src/typeapi/backport/inspect.py
+++ b/src/typeapi/backport/inspect.py
@@ -4,7 +4,7 @@ import builtins
 import functools
 import sys
 import types
-from typing import Any, Callable, Mapping, Optional
+from typing import Any, Callable, Dict, Mapping, Optional
 
 
 def get_annotations(
@@ -14,7 +14,7 @@ def get_annotations(
     locals: Optional[Mapping[str, Any]] = None,
     eval_str: bool = False,
     eval: Callable[[str, Any, Any], Any] = builtins.eval,
-) -> dict[str, Any]:
+) -> Dict[str, Any]:
     """Compute the annotations dict for an object.
 
     obj may be a callable, class, or module.

--- a/src/typeapi/backport/inspect.py
+++ b/src/typeapi/backport/inspect.py
@@ -1,0 +1,131 @@
+# Taken from CPython 3.11; with the addition of type hints and type ignore comments as well as an "eval" callback.
+
+from __future__ import annotations
+
+import builtins
+import functools
+import sys
+import types
+from typing import Any, Callable, Mapping
+
+
+def get_annotations(
+    obj: Any,
+    *,
+    globals: Mapping[str, Any] | None = None,
+    locals: Mapping[str, Any] | None = None,
+    eval_str: bool = False,
+    eval: Callable[[str, Any, Any], Any] = builtins.eval,
+) -> dict[str, Any]:
+    """Compute the annotations dict for an object.
+
+    obj may be a callable, class, or module.
+    Passing in an object of any other type raises TypeError.
+
+    Returns a dict.  get_annotations() returns a new dict every time
+    it's called; calling it twice on the same object will return two
+    different but equivalent dicts.
+
+    This function handles several details for you:
+
+      * If eval_str is true, values of type str will
+        be un-stringized using eval().  This is intended
+        for use with stringized annotations
+        ("from __future__ import annotations").
+      * If obj doesn't have an annotations dict, returns an
+        empty dict.  (Functions and methods always have an
+        annotations dict; classes, modules, and other types of
+        callables may not.)
+      * Ignores inherited annotations on classes.  If a class
+        doesn't have its own annotations dict, returns an empty dict.
+      * All accesses to object members and dict values are done
+        using getattr() and dict.get() for safety.
+      * Always, always, always returns a freshly-created dict.
+
+    eval_str controls whether or not values of type str are replaced
+    with the result of calling eval() on those values:
+
+      * If eval_str is true, eval() is called on values of type str.
+      * If eval_str is false (the default), values of type str are unchanged.
+
+    globals and locals are passed in to eval(); see the documentation
+    for eval() for more information.  If either globals or locals is
+    None, this function may replace that value with a context-specific
+    default, contingent on type(obj):
+
+      * If obj is a module, globals defaults to obj.__dict__.
+      * If obj is a class, globals defaults to
+        sys.modules[obj.__module__].__dict__ and locals
+        defaults to the obj class namespace.
+      * If obj is a callable, globals defaults to obj.__globals__,
+        although if obj is a wrapped function (using
+        functools.update_wrapper()) it is first unwrapped.
+    """
+    if isinstance(obj, type):
+        # class
+        obj_dict = getattr(obj, "__dict__", None)
+        if obj_dict and hasattr(obj_dict, "get"):
+            ann = obj_dict.get("__annotations__", None)
+            if isinstance(ann, types.GetSetDescriptorType):
+                ann = None
+        else:
+            ann = None
+
+        obj_globals = None
+        module_name = getattr(obj, "__module__", None)
+        if module_name:
+            module = sys.modules.get(module_name, None)
+            if module:
+                obj_globals = getattr(module, "__dict__", None)
+        obj_locals = dict(vars(obj))
+        unwrap = obj
+    elif isinstance(obj, types.ModuleType):
+        # module
+        ann = getattr(obj, "__annotations__", None)
+        obj_globals = getattr(obj, "__dict__")
+        obj_locals = None
+        unwrap = None
+    elif callable(obj):
+        # this includes types.Function, types.BuiltinFunctionType,
+        # types.BuiltinMethodType, functools.partial, functools.singledispatch,
+        # "class funclike" from Lib/test/test_inspect... on and on it goes.
+        ann = getattr(obj, "__annotations__", None)
+        obj_globals = getattr(obj, "__globals__", None)
+        obj_locals = None
+        unwrap = obj
+    else:
+        raise TypeError(f"{obj!r} is not a module, class, or callable.")
+
+    if ann is None:
+        return {}
+
+    if not isinstance(ann, dict):
+        raise ValueError(f"{obj!r}.__annotations__ is neither a dict nor None")
+
+    if not ann:
+        return {}
+
+    if not eval_str:
+        return dict(ann)
+
+    if unwrap is not None:
+        while True:
+            if hasattr(unwrap, "__wrapped__"):
+                unwrap = unwrap.__wrapped__  # type: ignore[union-attr]
+                continue
+            if isinstance(unwrap, functools.partial):
+                unwrap = unwrap.func  # type: ignore[union-attr, unreachable, assignment]
+                continue
+            break
+        if hasattr(unwrap, "__globals__"):
+            obj_globals = unwrap.__globals__  # type: ignore[union-attr]
+
+    if globals is None:
+        globals = obj_globals
+    if locals is None:
+        locals = obj_locals
+
+    return_value = {
+        key: value if not isinstance(value, str) else eval(value, globals, locals) for key, value in ann.items()  # type: ignore[arg-type] # noqa
+    }
+    return return_value

--- a/src/typeapi/backport/inspect.py
+++ b/src/typeapi/backport/inspect.py
@@ -109,7 +109,7 @@ def get_annotations(
     if unwrap is not None:
         while True:
             if hasattr(unwrap, "__wrapped__"):
-                unwrap = unwrap.__wrapped__  # type: ignore[union-attr]
+                unwrap = unwrap.__wrapped__  # type: ignore[attr-defined, union-attr]
                 continue
             if isinstance(unwrap, functools.partial):
                 unwrap = unwrap.func  # type: ignore[union-attr, unreachable, assignment]

--- a/src/typeapi/backport/inspect.py
+++ b/src/typeapi/backport/inspect.py
@@ -1,19 +1,17 @@
 # Taken from CPython 3.11; with the addition of type hints and type ignore comments as well as an "eval" callback.
 
-from __future__ import annotations
-
 import builtins
 import functools
 import sys
 import types
-from typing import Any, Callable, Mapping
+from typing import Any, Callable, Mapping, Optional
 
 
 def get_annotations(
     obj: Any,
     *,
-    globals: Mapping[str, Any] | None = None,
-    locals: Mapping[str, Any] | None = None,
+    globals: Optional[Mapping[str, Any]] = None,
+    locals: Optional[Mapping[str, Any]] = None,
     eval_str: bool = False,
     eval: Callable[[str, Any, Any], Any] = builtins.eval,
 ) -> dict[str, Any]:

--- a/src/typeapi/typehint.py
+++ b/src/typeapi/typehint.py
@@ -234,8 +234,9 @@ class TypeHint(object, metaclass=_TypeHintMeta):
             )
         if isinstance(self.source, ModuleType):
             return vars(self.source)
-        else:
-            return vars(self.source.__module__)  # type: ignore[no-any-return] # Should be a function or class, something that has __module__  # noqa: E501
+        if isinstance(self.source, Mapping):
+            return self.source
+        return vars(self.source.__module__)  # type: ignore[no-any-return] # Should be a function or class, something that has __module__  # noqa: E501
 
 
 class ClassTypeHint(TypeHint):


### PR DESCRIPTION
Support evaluation of future type hints in `typing.get_annotations()` and add new `typing.get_annotations(eval_str)` parameter. We backport a modified version of `inspect.get_annotations()` from Python 3.11 for this.